### PR TITLE
Removing Exception for ShellCheck

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -70,4 +70,4 @@ jobs:
         action: lint
         deny-warnings: true
         deny-notes: true
-        except: TodoComment ContainerUri TrailingComma ShellCheck
+        except: TodoComment ContainerUri TrailingComma


### PR DESCRIPTION
## Description
- With a recent bug fix in Sprocket Action, this PR removes the "ShellCheck" exception.

## Testing
- Works great, see this GitHub Action for evidence: https://github.com/getwilds/ww-star-deseq2/actions/runs/14933430448/job/41955153246?pr=10